### PR TITLE
debug yq error

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,74 @@
+name: Publish to crates.io
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      # Install Rust
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      # Use rust-cache for dependencies
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: chrisdickinson/setup-yq@latest
+
+      # Fetch the current version from Cargo.toml
+      - name: Extract current version
+        id: version
+        run: |
+          version=$(yq -r .package.version Cargo.toml)
+          echo "version=$version" >> $GITHUB_ENV
+
+      - name: Verify version bump
+        run: |
+          published_version=$(cargo search rasterfakers --limit 1 | grep -oP 'rasterfakers\s*=\s*"\K[0-9]+\.[0-9]+\.[0-9]+' )
+          echo "Published version on crates.io: $published_version"
+          echo "Local version in Cargo.toml: $version"
+          if [ "$published_version" = "$version" ]; then
+            echo "Error: Version $version is already published. Please bump the version in Cargo.toml before publishing."
+            exit 1
+          fi
+
+      # Set up GDAL environment with Pixi
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          activate-environment: true
+          cache: true
+          cache-write: false
+          manifest-path: build/pixi.toml
+
+      # Tweak environment to find GDAL
+      - name: Tweak environment to find GDAL
+        run: |
+          echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
+
+      - name: Fmt
+        run: cargo fmt -- --check
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Test
+        run: cargo test
+
+      # Publish to crates.io
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --token $CARGO_REGISTRY_TOKEN


### PR DESCRIPTION
the exisitng `yq` command did work locally so I am wondering why [gh action](https://github.com/pt20/rasterfakers/actions/runs/11505113836/job/32026116883) gave following error

```
yq: Error running jq: ParserError: did not find expected <document start>
  in "Cargo.toml", line 2, column 1.
jq: error (at <stdin>:1): Cannot index array with string "package"
```